### PR TITLE
fix: validate current user

### DIFF
--- a/src/NextcloudApiContext.php
+++ b/src/NextcloudApiContext.php
@@ -175,7 +175,7 @@ class NextcloudApiContext implements Context {
 		}
 		$fullUrl = $this->baseUrl . $url;
 		$client = new Client();
-		if (!empty($this->currentUser)) {
+		if (!is_null($this->currentUser)) {
 			$options = array_merge(
 				['cookies' => $this->getUserCookieJar($this->currentUser)],
 				$options


### PR DESCRIPTION
When we start the class, the default value is null, when we set an empty user, will be defined to empty string.