### PR TITLE
feat: add response header and body assertion steps

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -139,6 +139,14 @@ final class FeatureContext extends NextcloudApiContext {
 		));
 	}
 
+	#[Given('set the response with :header header :value to:')]
+	public function setTheResponseWithHeaderTo(string $header, string $value, PyStringNode $response): void {
+		$this->mockServer->setDefaultResponse(new MockWebServerResponse(
+			(string) $response,
+			[$header => $value]
+		));
+	}
+
 	/**
 	 * @inheritDoc
 	 */

--- a/features/test.feature
+++ b/features/test.feature
@@ -315,3 +315,27 @@ Feature: Test this extension
   Scenario: Wait for seconds
     When wait for 1 seconds
     When past 1 second since wait step
+
+  Scenario: Test response header assertion matches expected value
+    When set the response with "Content-Type" header "application/json" to:
+      """
+      {"ok":true}
+      """
+    And sending "POST" to "/"
+    Then the response header "Content-Type" should contain "application/json"
+
+  Scenario: Test response body is not empty
+    When set the response to:
+      """
+      hello
+      """
+    And sending "POST" to "/"
+    Then the response body should not be empty
+
+  Scenario: Test response body matches a regular expression
+    When set the response to:
+      """
+      %PDF-1.4 binary content here
+      """
+    And sending "POST" to "/"
+    Then the response body should match the regular expression "^%PDF"

--- a/src/NextcloudApiContext.php
+++ b/src/NextcloudApiContext.php
@@ -361,7 +361,7 @@ class NextcloudApiContext implements Context {
 
 	#[Given('the response header :header should contain :value')]
 	public function theResponseHeaderShouldContain(string $header, string $value): void {
-		$actual = strtolower((string)$this->response->getHeaderLine($header));
+		$actual = strtolower($this->response->getHeaderLine($header));
 		Assert::assertStringContainsString(strtolower($value), $actual, sprintf('Response header "%s" does not contain "%s"', $header, $value));
 	}
 

--- a/src/NextcloudApiContext.php
+++ b/src/NextcloudApiContext.php
@@ -359,6 +359,25 @@ class NextcloudApiContext implements Context {
 		Assert::assertEquals($code, $currentCode, $this->response->getBody()->getContents());
 	}
 
+	#[Given('the response header :header should contain :value')]
+	public function theResponseHeaderShouldContain(string $header, string $value): void {
+		$actual = strtolower((string)$this->response->getHeaderLine($header));
+		Assert::assertStringContainsString(strtolower($value), $actual, sprintf('Response header "%s" does not contain "%s"', $header, $value));
+	}
+
+	#[Given('the response body should not be empty')]
+	public function theResponseBodyShouldNotBeEmpty(): void {
+		$this->response->getBody()->rewind();
+		Assert::assertNotSame('', $this->response->getBody()->getContents(), 'Response body is empty');
+	}
+
+	#[Given('the response body should match the regular expression :pattern')]
+	public function theResponseBodyShouldMatchTheRegularExpression(string $pattern): void {
+		$this->response->getBody()->rewind();
+		$content = $this->response->getBody()->getContents();
+		Assert::assertMatchesRegularExpression('#' . $pattern . '#', $content, sprintf('Response body does not match pattern "%s"', $pattern));
+	}
+
 	/**
 	 * @throws \InvalidArgumentException
 	 */


### PR DESCRIPTION
## What

Adds three composable step definitions to `NextcloudApiContext`:

```gherkin
Then the response header "Content-Type" should contain "application/json"
And the response body should not be empty
And the response body should match the regular expression "^%PDF"
```

## Why

These were implemented in the consumer app (`libresign`) as local `FeatureContext` steps. Since they are generic enough to be useful to any Nextcloud app using this library, they belong here.

## Changes

- `src/NextcloudApiContext.php` — three new step definitions
- `features/bootstrap/FeatureContext.php` — new helper step to set mock response headers for test isolation
- `features/test.feature` — three scenarios covering the new steps